### PR TITLE
[問題修正] 回合開始時設定預設使用者 url

### DIFF
--- a/frontend/components/game-avatar.vue
+++ b/frontend/components/game-avatar.vue
@@ -3,7 +3,7 @@
 		<div class="avatar">
 			<img v-if="!round" :src="playerAvatar" :alt="avatar" />
 			<div v-else class="avatar-empty">
-				<img src="" alt="" />
+				<img :src="emptyPlayer ? defaultPlayer : ''" alt="" />
 				<p class="font-cubic">{{ bagScore }}</p>
 			</div>
 
@@ -33,6 +33,8 @@
 <script setup>
 	import { compose, defaultTo, isEmpty, isNil, path } from "ramda";
 
+	const defaultPlayer = '/player.png'
+
 	const props = defineProps({
 		user: {
 			type: Object,
@@ -55,7 +57,7 @@
 	});
 
 	const playerAvatar = computed(() => {
-		return compose(defaultTo("./player.png"), path(["avatar"]))(user.value);
+		return compose(defaultTo(defaultPlayer), path(["avatar"]))(user.value);
 	});
 
 	const playerIsReady = computed(() => {


### PR DESCRIPTION
### 目前回合開始時沒有使用者資料的大頭像會呈現灰色

增加預設頭像判斷