### PR TITLE
[問題修正] 公告卷軸樣式調整

### DIFF
--- a/frontend/components/game-bulletin.vue
+++ b/frontend/components/game-bulletin.vue
@@ -72,9 +72,16 @@ onMounted(() => {
   overflow-y: scroll;
   height: 100%;
   padding-right: 5px;
+  scrollbar-width: thin;
+	scrollbar-color: rgba(4, 4, 4, 0.35)  rgba(132, 132, 132, 0.2);
 }
 .game-bulletin__wrapper::-webkit-scrollbar {
   width: 16px;
+}
+
+.game-bulletin__wrapper::-webkit-scrollbar-track{
+	background-color: rgba(132, 132, 132, 0.2);
+	border-radius: 10px;
 }
 
 .game-bulletin__wrapper::-webkit-scrollbar-thumb {


### PR DESCRIPTION
### 卷軸樣式 chrome 與 firefox 不一致

如附圖
![Screenshot 2023-06-18 at 4 07 32 PM](https://github.com/Game-as-a-Service/IncanGold/assets/126720593/2bd03794-8dec-4062-be1a-6ae7cff7cd4e)
